### PR TITLE
Update from beta to prime

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,21 @@ The Federal Election Commission (FEC) releases information to the public about m
 
 Are you interested in seeing how much money a candidate raised? Or spent? How much debt they took on? Who contributed to their campaign? The FEC is the authoritative source for that information.
 
-betaFEC is a collaboration between [18F](http://18f.gsa.gov) and the FEC. It aims to make campaign finance information more accessible (and understandable) to all users. 
+The new FEC.gov is a collaboration between [18F](http://18f.gsa.gov) and the FEC. It aims to make campaign finance information more accessible (and understandable) to all users. 
 
 ## FEC repositories
 We welcome you to explore, make suggestions, and contribute to our code. 
 
-This repository, [FEC](https://github.com/18F/fec), is a general discussion forum. We [compile feedback](https://github.com/18F/fec/issues) from betaFEC’s feedback widget here. This is the best place to submit general feedback.
+This repository, [FEC](https://github.com/18F/fec), is a general discussion forum. We [compile feedback](https://github.com/18F/fec/issues) from the FEC.gov feedback widget here. This is the best place to submit general feedback.
 
 ### All repositories
-- [FEC](https://github.com/18F/fec): a general discussion forum. We [compile feedback](https://github.com/18F/fec/issues) from betaFEC’s feedback widget here, and this is the best place to submit general feedback.
-- [openFEC](https://github.com/18F/openfec): betaFEC’s API
-- [openFEC-web-app](https://github.com/18f/openfec-web-app): the betaFEC web app for exploring campaign finance data
+- [FEC](https://github.com/18F/fec): a general discussion forum. We [compile feedback](https://github.com/18F/fec/issues) from the FEC.gov feedback widget here, and this is the best place to submit general feedback.
+- [openFEC](https://github.com/18F/openfec): The first RESTful API for the Federal Election Commission
+- [openFEC-web-app](https://github.com/18f/openfec-web-app): the FEC’s web app for exploring campaign finance data
 - [fec-eregs](https://github.com/18F/fec-eregs): the FEC's new Code of Federal Regulations explorer
 - [fec-style](https://github.com/18F/fec-style): shared styles and user interface components
-- [fec-cms](https://github.com/18F/fec-cms): the content management system (CMS) for betaFEC
-- [fec-proxy](https://github.com/18F/fec-proxy): the proxy application to manage and route requests coming to betaFEC site
+- [fec-cms](https://github.com/18F/fec-cms): the content management system (CMS) for the new FEC.gov
+- [fec-proxy](https://github.com/18F/fec-proxy): the proxy application to manage and route requests coming to the new FEC.gov site
 - [swagger-ui](https://github.com/18F/swagger-ui) fork of swagger for API documentaion 
 - [fec-infrastructure](https://github.com/18F/fec-infrastructure): manages the gov cloud RDS instances
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository, [FEC](https://github.com/18F/fec), is a general discussion foru
 
 ### All repositories
 - [FEC](https://github.com/18F/fec): a general discussion forum. We [compile feedback](https://github.com/18F/fec/issues) from the FEC.gov feedback widget here, and this is the best place to submit general feedback.
-- [openFEC](https://github.com/18F/openfec): The first RESTful API for the Federal Election Commission
+- [openFEC](https://github.com/18F/openfec): the first RESTful API for the Federal Election Commission
 - [openFEC-web-app](https://github.com/18f/openfec-web-app): the FEC’s web app for exploring campaign finance data
 - [fec-eregs](https://github.com/18F/fec-eregs): the FEC's new Code of Federal Regulations explorer
 - [fec-style](https://github.com/18F/fec-style): shared styles and user interface components


### PR DESCRIPTION
This replaces written references in the README to `betaFEC` with phrases like `FEC.gov` or `the FEC` or `the new FEC.gov`.